### PR TITLE
Updated Geo / Geo+IOC queries with flags

### DIFF
--- a/LogScale-and-FLTR/Packages/CrowdStrike-FLTR/crowdstrike-fltr-content/src/queries/NetworkConnections-GeoIPLookupswithflag.yaml
+++ b/LogScale-and-FLTR/Packages/CrowdStrike-FLTR/crowdstrike-fltr-content/src/queries/NetworkConnections-GeoIPLookupswithflag.yaml
@@ -1,0 +1,42 @@
+name: Network Connections - GeoIP Lookups with flag
+visualization:
+  options: {}
+  type: table-view
+$schema: https://schemas.humio.com/query/v0.1.0
+timeInterval:
+  isLive: false
+  start: 1d
+queryString: |+
+  #event_simpleName = NetworkConnectIP4
+
+  // Check the local address first.
+  | case {
+      // Apply when the LocalAddressIP4 is a non-RFC1918 IP address.
+      !cidr(LocalAddressIP4, subnet=["224.0.0.0/4", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8", "169.254.0.0/16", "0.0.0.0/32"])
+        | ipLocation(LocalAddressIP4)
+        | match(file="geo_mapping.csv", column=CountryCode, field=LocalAddressIP4.country, include=["Country", "Continent", "Flag"], ignoreCase=true, strict=false);
+      * | LocalAddressIP4.country:="PrivateIP" | Country:="PrivateIP" | Continent:="PrivateIP" | Flag:="NoFlag";
+    }
+
+  // Check the remote address.
+  | case {
+      // Apply when the dst_ip is a non-RFC1918 IP address.
+      !cidr(RemoteAddressIP4, subnet=["224.0.0.0/4", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8", "169.254.0.0/16", "0.0.0.0/32"])
+        | ipLocation(RemoteAddressIP4)
+        | match(file="geo_mapping.csv", column=CountryCode, field=RemoteAddressIP4.country, include=["Country", "Continent", "Flag"], ignoreCase=true, strict=false);
+      * | RemoteAddressIP4.country:="PrivateIP" | Country:="PrivateIP" | Continent:="PrivateIP" | Flag:="NoFlag";
+    }
+
+  // Add the ComputerName
+  | $"crowdstrike/fltr-run:ComputerName"()
+
+  // Format the output.
+  | "Local IP":=rename(LocalAddressIP4)
+  | "Remote IP":=rename(RemoteAddressIP4)
+
+  // Example display of columns included in events, created as result of iplocation call, and fields added from lookup file match
+  // Alternate example: | table([@timestamp, ComputerName, "Local IP", "Remote IP", "Country", "IOC"], limit=1000)
+  | select([@timestamp, ComputerName, "Local IP", "Remote IP", Country, Continent, Flag])
+
+
+

--- a/LogScale-and-FLTR/Packages/CrowdStrike-FLTR/crowdstrike-fltr-content/src/queries/NetworkConnections-IOCandGeoIPLookupswithflag.yaml
+++ b/LogScale-and-FLTR/Packages/CrowdStrike-FLTR/crowdstrike-fltr-content/src/queries/NetworkConnections-IOCandGeoIPLookupswithflag.yaml
@@ -1,0 +1,50 @@
+name: Network Connections - IOC and GeoIP Lookups with flag
+visualization:
+  options: {}
+  type: table-view
+$schema: https://schemas.humio.com/query/v0.1.0
+timeInterval:
+  isLive: false
+  start: 1y
+queryString: |-
+  #event_simpleName = NetworkConnectIP4
+
+  // Check the local address first.
+  | case {
+      // Apply when the LocalAddressIP4 is a non-RFC1918 IP address.
+      !cidr(LocalAddressIP4, subnet=["224.0.0.0/4", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8", "169.254.0.0/16", "0.0.0.0/32"])
+        | ipLocation(LocalAddressIP4)
+        | match(file="geo_mapping.csv", column=CountryCode, field=LocalAddressIP4.country, include=["Country", "Continent", "Flag"], ignoreCase=true, strict=false)
+        | ioc:lookup(LocalAddressIP4, type="ip_address", confidenceThreshold=unverified);
+      *;
+    }
+
+  // Check the remote address.
+  | case {
+      // Apply when the dst_ip is a non-RFC1918 IP address.
+      !cidr(RemoteAddressIP4, subnet=["224.0.0.0/4", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.0/8", "169.254.0.0/16", "0.0.0.0/32"])
+        | ipLocation(RemoteAddressIP4)
+        | match(file="geo_mapping.csv", column=CountryCode, field=RemoteAddressIP4.country, include=["Country", "Continent", "Flag"], ignoreCase=true, strict=false)
+        | ioc:lookup(RemoteAddressIP4, type="ip_address", confidenceThreshold=unverified);
+      *;
+    }
+
+  // Only grab events with IOC labels.
+  | ioc[0].labels=*
+
+  // Format IOC label information
+  | replace(",", with=" -- ", field=ioc[0].labels, as=IOCinfo)
+
+  // Add the ComputerName
+  | $"crowdstrike/fltr-run:ComputerName"()
+
+  // Format the output.
+  | "Local IP":=rename(LocalAddressIP4)
+  | "Remote IP":=rename(RemoteAddressIP4)
+
+  // | "IOC":=ioc[0].labels
+  // | "Country":=RemoteAddressIP4.country
+  // | table([@timestamp, ComputerName, "Local IP", "Remote IP", Country, "IOC"], limit=1000)
+
+  // Display columns with all defined formatting
+  | select([@timestamp, ComputerName, "Local IP", "Remote IP", Country, Continent, Flag, IOCinfo])


### PR DESCRIPTION
* Split out separate Geo query that includes full country name and flag, and will show without relying on IOC match

* Created new Geo+IOC query that shows full country name and flag, and also formatted the IOC field for readability (added "--" between values vs. just single comma.